### PR TITLE
Fix: Annotate methods magically delegated to route collection

### DIFF
--- a/src/Seesaw.php
+++ b/src/Seesaw.php
@@ -2,6 +2,14 @@
 
 use FastRoute\BadRouteException;
 
+/**
+ * @method RouteCollection add(Route $route)
+ * @method RouteCollection addGroup(RouteGroup $group)
+ * @method RouteGroup[] getGroups()
+ * @method bool routeIsRegistered($route)
+ * @method Route|bool findByAction($action)
+ * @method RouteGroup|bool findGroupByRoute($route)
+ */
 class Seesaw
 {
     /**


### PR DESCRIPTION
This PR
- [x] adds class-level annotations to `Seesaw` for methods which are magically delegated to the `RouteCollection`
